### PR TITLE
Display Watson Analysis

### DIFF
--- a/client/src/Entry.js
+++ b/client/src/Entry.js
@@ -1,41 +1,83 @@
 import React, {Component} from 'react';
 import axios from 'axios';
+import Response from './Response';
 
 class Entry extends Component {
+	
 	constructor(props) {
 		super(props)
 		this.state = {
-			entry: ''
+			entry: '',
+			tones: [{
+				tone_name: ''
+			}],
+			sentences: []
 		}
 	}
 
 	onChange(e) {
 		var text = e.target.value
 		this.setState({
-			entry: text
+			entry: text,
 		})
 	}
 
 	onClick() {
+		
 		axios.post('/watson', {
-			entry: this.state.entry
-		})
-		.then(function(response) {
-			console.log(response)
-		})
-		.catch(function(error) {
-			console.log(error)
+				text: this.state.entry
+			})
+			.then(function(response) {
+				//Refernce to link objects
+				
+			})
+			.catch(function(error) {
+				console.log(error)
+		});
+		//Have to use AJAX calls with react, calls a function to grab "instance" of last post on /watson route
+		this.grabCache()
+	}
+
+	grabCache() {
+		axios.get('/watson')
+		.then( (response) => {
+			//Refernce to link objects
+			console.log(response.data.text)
+			var text = response.data.text
+			var tones = text.document_tone.tones
+			var sentences;
+			if (text.sentences_tone) {
+				sentences = text.sentences_tone
+			}
+			this.setState({
+				tones: tones,
+				sentences: sentences
+			})
+			//Add in conditonal for sentences later
+			//Only entries with multiple sentences get this array, so if not checked could cause a problem
+			
 		});
 	}
 
+
+
     render(){
+    	var name = this.state.tones[0].tone_name || ''
         return(
             <div>
-                <h3>Use the <span className='unique'>IBM's Watson Cognitive Services</span> to detect tone in written text.</h3>
+                <h5>Use the <span className='unique'>IBM Watson Cognitive Services AI</span> to detect tone in written text.</h5>
                 <form id='watson-tone-entry'>
                 	<textarea rows='5' cols='100' placeholder='Insert text here to detect tone' onChange={ (e) => this.onChange(e) } />
                 	<input type='button' onClick={ (e) => this.onClick(e) } value='Analyze'/>
                 </form>
+                <div id='entry-response'>
+                	<h5>Watson Analysis:</h5>
+                	<p><span className='response'>Text</span></p>
+                	<p>{this.state.entry}</p>
+                	<div id='entry-response'>
+                		<h4>Watson Tone: {name}</h4>
+                	</div>
+                </div>
             </div>
         )
     }

--- a/client/src/Profile.js
+++ b/client/src/Profile.js
@@ -20,11 +20,6 @@ class Profile extends Component {
         be much faster to show up. */
     //}
 
-    /* THIS IS FOR THE ENTRY COMPONENT */
-
-
-
-    /* END OF ENTRY COMPONENT */
 
     render(){
         return(

--- a/client/src/Response.js
+++ b/client/src/Response.js
@@ -1,10 +1,20 @@
 import React, {Component} from 'react';
 
 class Response extends Component {
+
+	constructor(props) {
+		super(props)
+		this.state = {
+			tones: this.props.tones
+		}
+	}
+
+	
+
     render(){
         return(
             <div>
-                here's the response to the entry
+                Here's the response to the entry
             </div>
         )
     }

--- a/client/src/WatsonData.js
+++ b/client/src/WatsonData.js
@@ -3,6 +3,13 @@ import Entry from './Entry';
 import Response from './Response';
 
 class WatsonData extends Component {
+	constructor(props) {
+		super(props)
+		this.state = {
+			
+		}
+	}
+
   render(){
     return(
       <div>

--- a/routes/watson.js
+++ b/routes/watson.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 var isLoggedIn = require('../middleware/isLoggedIn');
 var ToneAnalyzerV3 = require('watson-developer-cloud/tone-analyzer/v3');
-var submitted;
+var instance;
 
 var tone_analyzer = new ToneAnalyzerV3({
   username: 'a32ea9d2-b998-443b-87b7-6aef61ba95d3',
@@ -15,19 +15,22 @@ var tone_analyzer = new ToneAnalyzerV3({
 
 
 router.get('/', function(req, res, next) {
-	res.send('This is the watson page');
+	console.log(instance)
+	res.json({text: instance});
 })
 
 router.post('/', function(req, res, next) {
-	console.log(req);
 	
-	tone_analyzer.tone({ text: req.body.entry },
+	tone_analyzer.tone({ text: req.body.text },
 	  function(err, tone) {
 	    if (err)
 	      console.log(err);
 	    else
 	      console.log(JSON.stringify(tone, null, 2));
+	  	  instance = undefined;
+	  	  instance = tone;
 	});
+	res.redirect('/')
 })
 
 module.exports = router;


### PR DESCRIPTION
What's new:
- I have a headache
- Axios calls to post and automatically gets data
- Temporary "instance" variable in watson.js router to save what was just sent by the user and for it to be sent back on the next get request
- New state full of arrays and an outline of an object (outline probably won't exist in the final version)
- Some boilerplate structuring of the response component, which can be used to render chart feedback

TODO:
- Still check for sentences_tone object, not every entry will have multiple sentences and if it doesn't this object will not appear in the response. It will be important to add in conditionals that can check for this and react accordingly to display information correctly.
- Map out the arrays in the state and grab more information from the request.